### PR TITLE
Fix NullPointerException, only close client in ClientInjectionHandler when client is set (#118)

### DIFF
--- a/fabric8/src/main/java/io/javaoperatorsdk/jenvtest/junit/Fabric8ClientInjectionHandler.java
+++ b/fabric8/src/main/java/io/javaoperatorsdk/jenvtest/junit/Fabric8ClientInjectionHandler.java
@@ -45,7 +45,9 @@ public class Fabric8ClientInjectionHandler implements ClientInjectionHandler {
 
   @Override
   public void cleanup(ExtensionContext extensionContext) {
-    client.close();
+    if (client != null) {
+      client.close();
+    }
   }
 
   public static Optional<Field> getFieldForKubeClientInjection(ExtensionContext extensionContext,


### PR DESCRIPTION
Fix NullPointerException, only close client in ClientInjectionHandler when client is set (#118)