### PR TITLE
Use HTTP/1.1 to perform readiness check

### DIFF
--- a/core/src/main/java/io/javaoperatorsdk/jenvtest/KubeAPIServer.java
+++ b/core/src/main/java/io/javaoperatorsdk/jenvtest/KubeAPIServer.java
@@ -37,6 +37,11 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
   }
 
   public void start() {
+    startAsync();
+    waitUntilReady();
+  }
+
+  public void startAsync() {
     log.debug("Stating API Server. Using jenvtest dir: {}", config.getJenvtestDir());
     binaryManager.initAndDownloadIfRequired();
     certManager.createCertificatesIfNeeded();
@@ -45,6 +50,9 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
     if (config.isUpdateKubeConfig()) {
       kubeConfig.updateKubeConfig(apiServerPort);
     }
+  }
+
+  public void waitUntilReady() {
     kubeApiServerProcess.waitUntilReady();
     log.debug("API Server ready to use");
   }

--- a/core/src/main/java/io/javaoperatorsdk/jenvtest/KubeAPIServer.java
+++ b/core/src/main/java/io/javaoperatorsdk/jenvtest/KubeAPIServer.java
@@ -37,11 +37,6 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
   }
 
   public void start() {
-    startAsync();
-    waitUntilReady();
-  }
-
-  public void startAsync() {
     log.debug("Stating API Server. Using jenvtest dir: {}", config.getJenvtestDir());
     binaryManager.initAndDownloadIfRequired();
     certManager.createCertificatesIfNeeded();
@@ -50,9 +45,6 @@ public class KubeAPIServer implements UnexpectedProcessStopHandler {
     if (config.isUpdateKubeConfig()) {
       kubeConfig.updateKubeConfig(apiServerPort);
     }
-  }
-
-  public void waitUntilReady() {
     kubeApiServerProcess.waitUntilReady();
     log.debug("API Server ready to use");
   }

--- a/core/src/main/java/io/javaoperatorsdk/jenvtest/process/KubeAPIServerProcess.java
+++ b/core/src/main/java/io/javaoperatorsdk/jenvtest/process/KubeAPIServerProcess.java
@@ -89,9 +89,7 @@ public class KubeAPIServerProcess {
     var readinessChecker = new ProcessReadinessChecker();
     var timeout = config.getStartupTimeout();
     var startTime = System.currentTimeMillis();
-    // the 1.29.0 binary has issue with this. Will temporarily comment out and further investigate.
-    // But with this now all the executions are failing
-    // readinessChecker.waitUntilReady(apiServerPort, "readyz", KUBE_API_SERVER, true, timeout);
+    readinessChecker.waitUntilReady(apiServerPort, "readyz", KUBE_API_SERVER, true, timeout);
     int newTimout = (int) (timeout - (System.currentTimeMillis() - startTime));
     readinessChecker.waitUntilDefaultNamespaceAvailable(apiServerPort, binaryManager, certManager,
         config, newTimout);

--- a/core/src/main/java/io/javaoperatorsdk/jenvtest/process/ProcessReadinessChecker.java
+++ b/core/src/main/java/io/javaoperatorsdk/jenvtest/process/ProcessReadinessChecker.java
@@ -179,6 +179,7 @@ public class ProcessReadinessChecker {
           null);
       return HttpClient.newBuilder()
           .sslContext(sslContext)
+          .version(HttpClient.Version.HTTP_1_1)
           .build();
     } catch (NoSuchAlgorithmException | KeyManagementException e) {
       throw new JenvtestException(e);

--- a/core/src/main/java/io/javaoperatorsdk/jenvtest/process/ProcessReadinessChecker.java
+++ b/core/src/main/java/io/javaoperatorsdk/jenvtest/process/ProcessReadinessChecker.java
@@ -177,6 +177,10 @@ public class ProcessReadinessChecker {
               }
           },
           null);
+      // Set protocol to HTTP/1.1 for unauthenticated invocations of "GET /readyz". Sending
+      // unauthenticated requests using HTTP/2 is problematic on Kubernetes >=1.29, which enables
+      // denial-of-service mitigation for authenticated HTTP/2 by default with the
+      // UnauthenticatedHTTP2DOSMitigation feature gate.
       return HttpClient.newBuilder()
           .sslContext(sslContext)
           .version(HttpClient.Version.HTTP_1_1)


### PR DESCRIPTION
This change re-enables the readiness check, using HTTP/1.1 instead of HTTP/2 to invoke it. The readiness checks are unauthenticated and are throttled when the feature gate UnauthenticatedHTTP2DOSMitigation is set to true, which is the default starting in Kubernetes 1.29 (see https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates). This was the cause of the "GOAWAY received" errors that have been observed on Kubernetes 1.29.

This change also decouples starting of the servers from waiting until they become ready, so that if the readiness check fails due to some error that propagates out of the polling loop (e.g. IOException), the caller is free to catch it and continue waiting.